### PR TITLE
Get bench data

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,5 +1,5 @@
 import express from 'express'
-import {Log} from '../db/models'
+import {Bench, Log} from '../db/models'
 
 const router = express.Router()
 
@@ -20,6 +20,29 @@ router.get('/logs/:id', async (req: express.Request, res: express.Response) => {
       return res.status(404).json({message: `id=${logId}のlogは存在しません`})
     }
     res.json({ log })
+  } catch (e) {
+    res.status(500).json({message: e})
+  }
+})
+
+router.get('/benches', async (req: express.Request, res: express.Response) => {
+  try {
+    const benches = await Bench.findAll()
+    res.json({ benches })
+  } catch (e) {
+    res.status(500).json({message: e})
+  }
+})
+
+router.get('/benches/:id', async (req: express.Request, res: express.Response) => {
+  const benchId = req.params.id
+  try {
+    const bench = await Bench.findByPk(benchId)
+    if (bench === null) {
+      return res.status(404).json({message: `id=${benchId}のbenchは存在しません`})
+    }
+    // どのデータ取得するか調整
+    res.json({ bench })
   } catch (e) {
     res.status(500).json({message: e})
   }

--- a/src/db/migrations/20210721072510-create-log.js
+++ b/src/db/migrations/20210721072510-create-log.js
@@ -14,7 +14,7 @@ module.exports = {
       body: {
         type: Sequelize.TEXT
       },
-      // 外部キー
+      // 外部キー追加
       benchId: {
         allowNull: false,
         type: Sequelize.INTEGER

--- a/src/db/migrations/20210731064133-create-bench.js
+++ b/src/db/migrations/20210731064133-create-bench.js
@@ -1,7 +1,7 @@
 'use strict';
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    await queryInterface.createTable('logs', {
+    await queryInterface.createTable('Benches', {
       id: {
         allowNull: false,
         autoIncrement: true,
@@ -10,14 +10,6 @@ module.exports = {
       },
       name: {
         type: Sequelize.STRING
-      },
-      body: {
-        type: Sequelize.TEXT
-      },
-      // 外部キー
-      benchId: {
-        allowNull: false,
-        type: Sequelize.INTEGER
       },
       createdAt: {
         allowNull: false,
@@ -30,6 +22,6 @@ module.exports = {
     });
   },
   down: async (queryInterface, Sequelize) => {
-    await queryInterface.dropTable('logs');
+    await queryInterface.dropTable('Benches');
   }
 };

--- a/src/db/models/index.ts
+++ b/src/db/models/index.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { Sequelize, Model, DataTypes } from 'sequelize'
+import { Sequelize, Model, DataTypes, Association, HasManyCreateAssociationMixin } from 'sequelize'
 
 const basename = path.basename(__filename)
 const env = process.env.NODE_ENV || 'development';
@@ -12,14 +12,60 @@ if (config.use_env_variable) {
   sequelize = new Sequelize(config.database, config.username, config.password, config);
 }
 
+class Bench extends Model {
+  public id!: number;
+  public name!: string;
+  
+  // 追加する
+
+  public readonly createdAt!: Date;
+  public readonly updatedAt!: Date;
+
+  public createLog!: HasManyCreateAssociationMixin<Log>
+
+  public static associations() {
+    // logs: Association<Bench, Log>;
+    this.hasMany(Log, {
+      sourceKey: 'id',
+      foreignKey: 'benchId',
+      constraints: false,
+    })
+  };
+}
+
+Bench.init(
+  {
+    id: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    // 追加する
+  },
+  {
+    sequelize,
+    tableName: "benches",
+  }
+);
 class Log extends Model {
 
   public id!: number
   public name!: string
   public body!: string
 
+  // 外部キー
+  public benchId!: number;
+
   public readonly createdAt!: Date;
   public readonly updatedAt!: Date;
+
+  public static associations() {
+    this.belongsTo(Bench, { foreignKey: 'benchId', constraints: false });
+  }
 }
 
 Log.init(
@@ -37,6 +83,11 @@ Log.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
+    // 外部キー
+    benchId: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      allowNull: false,
+    }
   },
   {
     sequelize,
@@ -44,4 +95,6 @@ Log.init(
   }
 );
 
-export { Log }
+
+export { Log, Bench }
+

--- a/src/db/models/index.ts
+++ b/src/db/models/index.ts
@@ -16,7 +16,9 @@ class Bench extends Model {
   public id!: number;
   public name!: string;
   
-  // 追加する
+  // 追加する（migrationも反映させる）
+  // comment
+  // score
 
   public readonly createdAt!: Date;
   public readonly updatedAt!: Date;
@@ -24,7 +26,6 @@ class Bench extends Model {
   public createLog!: HasManyCreateAssociationMixin<Log>
 
   public static associations() {
-    // logs: Association<Bench, Log>;
     this.hasMany(Log, {
       sourceKey: 'id',
       foreignKey: 'benchId',
@@ -57,7 +58,7 @@ class Log extends Model {
   public name!: string
   public body!: string
 
-  // 外部キー
+  // 外部キー追加
   public benchId!: number;
 
   public readonly createdAt!: Date;
@@ -83,7 +84,7 @@ Log.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
-    // 外部キー
+    // 外部キー追加
     benchId: {
       type: DataTypes.INTEGER.UNSIGNED,
       allowNull: false,


### PR DESCRIPTION
変更した点
- benchのmigrationファイル作成
- benchのmodelをlogを参考に一旦記述
- get /benches/, get/benches/:id を一旦記述
- 1対多の関係をmodelファイルに記述（動作確認できていないので正しい記述か確認できていないです。）
  - 多 : 1 = bench : logs で記述しています。（この認識合っているか前回確認するべきだったのですが忘れていました。）


まだ変更できていない点
- benchのmigrationファイルに必要なカラム追加
- migration実行
- benchデータ取得

参考にした記事
https://sequelize.org/master/manual/typescript.html
https://qiita.com/mima_ita/items/014dcb42872f3a10855b#%E3%83%9E%E3%82%A4%E3%82%B0%E3%83%AC%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%81%AE%E5%AE%9F%E8%A1%8C
https://karuta-kayituka.hatenablog.com/entry/2019/07/21/132814